### PR TITLE
Initial CRM tool with extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - run: python -m pip install --upgrade pip
+    - run: python -m pip install uv
+    - run: uv pip install -r requirements.in
+    - run: uv pip install -e .
+    - run: uv pip install build
+    - run: pytest -q
+    - run: python -m build
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,170 @@
 # crmd
+
+**crmd** is a terminal‑native CRM that keeps your customer data in flat YAML files and
+uses OpenAI on demand for planning and summaries.
+
+Features at a glance:
+
+- Fast commands: `add`, `list`, `log`, `plan`, `chat`, and a Textual dashboard.
+- Reminders, git‑powered undo, and simple stats.
+- Natural‑language scheduling with `schedule` and a persistent background `worker`.
+- Browser automation for Gmail drafts and one‑click social posts.
+- Built-in email sending and calendar event export.
+- Full-screen Textual UI and optional cloud sync.
+- Import/export, CSV import, and encrypted backups.
+- Everything lives in one file (`crmd.py`) so packaging stays lightweight.
+
+## Installation
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install uv
+uv pip install -r requirements.in  # dependencies
+
+# Or install system-wide once published:
+pip install crmd  # works on Linux, macOS and Windows
+```
+
+To install globally via pip once packaged, run `pip install crmd`.
+You can also build from source using `python -m build` which relies on the
+provided `pyproject.toml` and `setup.py`.
+
+To create a `.deb` package install `dpkg-deb` and run `scripts/build_deb.sh`.
+
+## Usage
+
+Export your OpenAI key once:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Alternatively store it once with:
+
+```bash
+crmd config set-api-key sk-...
+```
+
+Example workflow:
+
+```bash
+crmd add "Jordan Lee" --email jordan@example.com --tags vip
+crmd log "Jordan Lee" --summary "Intro email" --channel email
+crmd list
+crmd plan "Jordan Lee"
+crmd chat "Jordan Lee"    # interactive, `/exit` to quit
+crmd remind "Jordan Lee" "Check in" --in 30
+crmd due
+crmd search "Jordan"
+crmd draft-email "Jordan Lee" --subject "Hello"
+```
+
+### Additional commands
+
+- `summary NAME` – use OpenAI to generate a short summary of a contact.
+- `import-csv FILE` – bulk import contacts from a CSV file.
+- `notify-due` – send desktop notifications for due reminders.
+- `encrypt` – archive and encrypt your data directory with GPG.
+- `export-json NAME PATH` – save a contact as JSON.
+- `import-json PATH` – load a contact from JSON.
+- `delete NAME` – remove a contact.
+- `backup [PATH]` – tarball all data for backup.
+- `schedule-browser URL --at TIME` – open a URL later.
+- `schedule-post TEXT --at TIME [--platform x|facebook]` – post on social media later.
+- `worker` – background loop that executes scheduled tasks.
+- `graphs NAME` – show interaction counts with Textual.
+- `undo` – revert the last change to a contact using git.
+- `stats` – JSON totals for contacts, interactions and reminders.
+- `tag-all TAG NAMES...` – add a tag to multiple contacts.
+- `merge SRC DEST` – combine two contacts into one.
+- `export-csv PATH` – save all contacts to a CSV file.
+- `edit NAME` – open a contact YAML in `$EDITOR`.
+- `send-email NAME --subject S --body B` – send an email via SMTP.
+- `create-event NAME --when TIME --summary TEXT` – export an ICS file.
+- `fullscreen` – full-screen Textual UI.
+- `sync-cloud` – git push to a remote.
+- `list-tags` – list all unique tags.
+- `config set-api-key KEY` – store your OpenAI key in a config file.
+- `list --tag TAG` – filter contacts by tag.
+- `reminders [--clear N]` – list or delete reminders.
+- `tasks [--clear N]` – list or delete scheduled tasks.
+
+## Daemon / Service
+
+To run `crmd` periodically (for example to send reminders) you can use a
+systemd service. Create `~/.config/systemd/user/crmd.service`:
+
+```ini
+[Unit]
+Description=CRMD background service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/crmd dashboard
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+Then enable with:
+
+```bash
+systemctl --user enable crmd.service
+systemctl --user start crmd.service
+```
+
+This example runs the dashboard at login; adjust `ExecStart` for other tasks.
+
+## Scheduling Browser Actions
+
+`crmd` can understand natural language and turn it into a timed Gmail draft. Use
+`schedule` to create a task and `worker` to execute it in the background:
+
+```bash
+crmd schedule "draft follow up email to Aravind about the browser launch tomorrow at 08:30"
+crmd worker
+```
+
+This will open a Gmail draft at the specified time (if your system is running).
+
+You can also schedule social media posts:
+
+```bash
+crmd schedule-post "Check out our new release" --platform x --at "2025-06-21 10:00"
+```
+
+`worker` will then launch the relevant share URL when the time is reached.
+
+## Git Sync
+
+If your `CRMD_HOME` directory is a git repository, run:
+
+```bash
+crmd sync
+```
+
+This will add, commit, and push all changes so you can access them across devices.
+
+## Development
+
+Run tests with:
+
+```bash
+source .venv/bin/activate
+pytest
+```
+
+CI is configured via GitHub Actions in `.github/workflows/ci.yml`. Tagged
+releases will automatically publish to PyPI if the `PYPI_API_TOKEN` secret is
+set.
+
+For a quick visual overview, open `index.html` in your browser to see a minimal demo site styled like a terminal.
+
+## Next nice-to-haves
+
+- Mobile-friendly shell wrapper
+- Voice note recording
+- Local search index for speed
+- Contact deduplication suggestions

--- a/crmd.py
+++ b/crmd.py
@@ -1,0 +1,780 @@
+#!/usr/bin/env python3
+"""CRMD - terminal CRM with local YAML storage and optional OpenAI integration."""
+
+from __future__ import annotations
+import os
+import sys
+import json
+import datetime
+from pathlib import Path
+from typing import List
+
+import yaml
+import typer
+from rich import print
+from rich.table import Table
+from rich.prompt import Prompt
+import webbrowser
+import time
+import re
+import subprocess
+from collections import defaultdict
+
+try:
+    import openai
+except ImportError:  # allow running without the dependency in tests
+    openai = None
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+def data_dir() -> Path:
+    d = Path(os.environ.get("CRMD_HOME", Path.home() / ".crmd"))
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def reminders_file() -> Path:
+    return data_dir() / "reminders.txt"
+
+
+def config_path() -> Path:
+    return data_dir() / "config.yaml"
+
+
+def load_config() -> dict:
+    p = config_path()
+    if p.exists():
+        return yaml.safe_load(p.read_text()) or {}
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    config_path().write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+
+def _path(name: str) -> Path:
+    safe = name.lower().replace(" ", "_")
+    return data_dir() / f"{safe}.yaml"
+
+
+def _load(name: str) -> dict:
+    p = _path(name)
+    if not p.exists():
+        typer.echo(f"[red]No contact named '{name}'")
+        raise typer.Exit(1)
+    return yaml.safe_load(p.read_text())
+
+
+def _save(record: dict) -> None:
+    _path(record["name"]).write_text(yaml.safe_dump(record, sort_keys=False))
+
+
+def _merge(a: dict, b: dict) -> None:
+    for k, v in b.items():
+        if isinstance(v, dict) and isinstance(a.get(k), dict):
+            _merge(a[k], v)
+        else:
+            a[k] = v
+
+
+# ---------------------------------------------------------------------------
+# OpenAI helper
+# ---------------------------------------------------------------------------
+
+
+def _ai(system: str, user: str) -> dict:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        cfg = load_config()
+        api_key = cfg.get("openai_api_key")
+    if not api_key:
+        print("[red]OpenAI key not configured")
+        raise typer.Exit(1)
+    if openai is None:
+        print("[red]openai package missing")
+        raise typer.Exit(1)
+    openai.api_key = api_key
+    res = openai.chat.completions.create(
+        model="o3",
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        response_format={"type": "json_object"},
+        temperature=0.3,
+    )
+    return json.loads(res.choices[0].message.content)
+
+
+# ---------------------------------------------------------------------------
+# Typer app
+# ---------------------------------------------------------------------------
+app = typer.Typer(add_help_option=True, rich_markup_mode="rich")
+config_app = typer.Typer()
+app.add_typer(config_app, name="config")
+
+
+@config_app.command("set-api-key")
+def config_set_api_key(key: str):
+    """Store OPENAI_API_KEY in the config file."""
+    cfg = load_config()
+    cfg["openai_api_key"] = key
+    save_config(cfg)
+    print("[green]✓ key saved")
+
+
+@config_app.command("show")
+def config_show():
+    """Print current configuration."""
+    cfg = load_config()
+    print(yaml.safe_dump(cfg, sort_keys=False))
+
+
+@app.command()
+def add(
+    name: str,
+    email: str = typer.Option(..., "--email", "-e"),
+    tags: str = typer.Option("", "--tags", "-t", help="comma separated"),
+):
+    """Add a new contact"""
+    if _path(name).exists():
+        print(f"[red]{name} already exists")
+        raise typer.Exit(1)
+    rec = {
+        "name": name,
+        "email": email,
+        "tags": [t.strip() for t in tags.split(",") if t.strip()],
+        "created": datetime.date.today().isoformat(),
+        "interactions": [],
+        "notes": [],
+    }
+    _save(rec)
+    print(f"[green]✓ added {name}")
+
+
+@app.command(name="list")
+def list_contacts(tag: str = typer.Option(None, "--tag")):
+    """List contacts, optionally filtering by tag."""
+    tab = Table(title="Contacts")
+    tab.add_column("Name")
+    tab.add_column("Email")
+    tab.add_column("Last")
+    tab.add_column("#Int")
+    for f in sorted(data_dir().glob("*.yaml")):
+        c = yaml.safe_load(f.read_text())
+        if tag and tag not in c.get("tags", []):
+            continue
+        last = c["interactions"][-1]["date"] if c["interactions"] else "-"
+        tab.add_row(c["name"], c.get("email", ""), last, str(len(c["interactions"])))
+    print(tab)
+
+
+@app.command()
+def log(
+    name: str,
+    summary: str = typer.Option(..., "--summary", "-s"),
+    channel: str = typer.Option("email", "--channel", "-c"),
+):
+    """Log an interaction"""
+    rec = _load(name)
+    rec["interactions"].append(
+        {
+            "date": datetime.date.today().isoformat(),
+            "channel": channel,
+            "summary": summary,
+        }
+    )
+    _save(rec)
+    print("[green]✓ logged")
+
+
+@app.command()
+def plan(name: str):
+    """AI next actions"""
+    rec = _load(name)
+    system = (
+        "You are an assistant suggesting concise next actions for a contact in a CRM. "
+        'Return JSON like {"actions":[{"date":"YYYY-MM-DD","action":"text"}]}'
+    )
+    result = _ai(system, json.dumps(rec))
+    print(json.dumps(result, indent=2))
+
+
+@app.command()
+def chat(name: str):
+    """Interactive AI chat that can update the record"""
+    rec = _load(name)
+    system = (
+        "You manage a YAML CRM record. Always reply JSON. "
+        "To update the record, include a 'patch' key with a JSON merge-patch."
+    )
+    while True:
+        msg = Prompt.ask("[bold cyan]You[/]")
+        if msg.lower() in {"/exit", "/quit", "/q"}:
+            break
+        resp = _ai(system + "\nCurrent record:\n" + json.dumps(rec), msg)
+        patch = resp.get("patch")
+        if patch:
+            _merge(rec, patch)
+            _save(rec)
+            print("[green]record updated")
+        if "assistant_reply" in resp:
+            print(resp["assistant_reply"])
+
+
+@app.command()
+def dashboard():
+    """Read-only Textual table"""
+    try:
+        from textual.app import App as TApp
+        from textual.widgets import DataTable
+    except Exception:
+        print("[red]Install textual to use dashboard")
+        raise typer.Exit(1)
+
+    class Dash(TApp):
+        BINDINGS = [("q", "quit", "Quit")]
+
+        def compose(self):
+            tbl = DataTable(zebra_stripes=True)
+            tbl.add_columns("Name", "Email", "Last", "#Int")
+            for f in sorted(data_dir().glob("*.yaml")):
+                c = yaml.safe_load(f.read_text())
+                last = c["interactions"][-1]["date"] if c["interactions"] else "-"
+                tbl.add_row(
+                    c["name"], c.get("email", ""), last, str(len(c["interactions"]))
+                )
+            yield tbl
+
+    Dash().run()
+
+
+@app.command()
+def search(keyword: str):
+    """Search contacts and interactions for a keyword."""
+    pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+    for f in sorted(data_dir().glob("*.yaml")):
+        c = yaml.safe_load(f.read_text())
+        haystack = json.dumps(c)
+        if pattern.search(haystack):
+            print(c["name"])
+
+
+@app.command()
+def remind(name: str, message: str, in_days: int = typer.Option(0, "--in")):
+    """Add a reminder entry"""
+    date = (datetime.date.today() + datetime.timedelta(days=in_days)).isoformat()
+    rf = reminders_file()
+    with rf.open("a") as fh:
+        fh.write(f"{date} {name}: {message}\n")
+    print("[green]✓ reminder added")
+
+
+@app.command()
+def due():
+    """Show due reminders"""
+    rf = reminders_file()
+    if not rf.exists():
+        return
+    today = datetime.date.today().isoformat()
+    for line in rf.read_text().splitlines():
+        date, rest = line.split(" ", 1)
+        if date <= today:
+            print(line)
+
+
+@app.command("reminders")
+def reminders(clear: int = typer.Option(None, "--clear", help="index to remove")):
+    """List all reminders or remove one by index."""
+    rf = reminders_file()
+    if not rf.exists():
+        return
+    lines = rf.read_text().splitlines()
+    if clear is not None:
+        if 0 <= clear < len(lines):
+            del lines[clear]
+            rf.write_text("\n".join(lines) + ("\n" if lines else ""))
+            print("[green]✓ removed")
+        return
+    for i, line in enumerate(lines):
+        print(f"{i}: {line}")
+
+
+@app.command()
+def sync():
+    """Run git add/commit/push in the data directory if it's a repo."""
+    if not (data_dir() / ".git").exists():
+        print("[red]No git repository in data dir")
+        raise typer.Exit(1)
+    subprocess.run(["git", "-C", str(data_dir()), "add", "."])
+    subprocess.run(["git", "-C", str(data_dir()), "commit", "-m", "sync"], check=False)
+    subprocess.run(["git", "-C", str(data_dir()), "push"], check=False)
+
+
+@app.command()
+def draft_email(name: str, subject: str = typer.Option(..., "--subject")):
+    """Use OpenAI to draft an email"""
+    rec = _load(name)
+    system = (
+        "You are an assistant drafting a short email. " 'Return JSON {"email":"text"}'
+    )
+    prompt = f"Compose an email to {rec['name']} about: {subject}."
+    result = _ai(system, prompt)
+    print(result.get("email", ""))
+
+
+@app.command()
+def schedule(instruction: str):
+    """Parse INSTRUCTION with OpenAI to create a timed Gmail draft task."""
+    sys_msg = (
+        "You are a parser that extracts scheduling info from the user's sentence.\n"
+        "Return JSON with keys run_at (YYYY-MM-DD HH:MM 24h), to (name), subject, body."
+    )
+    parsed = _ai(sys_msg, instruction)
+    run_at = parsed["run_at"]
+    contact = _load(parsed["to"])
+    tasks = _read_tasks()
+    tasks.append(
+        {
+            "time": run_at,
+            "url": _gmail_url(contact.get("email"), parsed["subject"], parsed["body"]),
+            "done": False,
+        }
+    )
+    _save_tasks(tasks)
+    print(f"[green]✓ task scheduled for {run_at}")
+
+
+def tasks_file() -> Path:
+    return data_dir() / "tasks.json"
+
+
+def _read_tasks() -> list:
+    f = tasks_file()
+    if f.exists():
+        return json.loads(f.read_text())
+    return []
+
+
+def _save_tasks(tasks: list) -> None:
+    tasks_file().write_text(json.dumps(tasks, indent=2))
+
+
+def _gmail_url(email: str, subject: str, body: str) -> str:
+    from urllib.parse import quote_plus
+
+    return (
+        "https://mail.google.com/mail/?view=cm&fs=1&tf=1"
+        f"&to={quote_plus(email)}&su={quote_plus(subject)}&body={quote_plus(body)}"
+    )
+
+
+@app.command("schedule-browser")
+def schedule_browser(
+    url: str, at: str = typer.Option(..., "--at", help="YYYY-MM-DD HH:MM")
+):
+    """Store a browser-opening task to run later."""
+    tasks = _read_tasks()
+    tasks.append({"time": at, "url": url, "done": False})
+    _save_tasks(tasks)
+    print("[green]✓ task scheduled")
+
+
+@app.command("schedule-post")
+def schedule_post(
+    text: str,
+    at: str = typer.Option(..., "--at", help="YYYY-MM-DD HH:MM"),
+    platform: str = typer.Option("x", "--platform", "-p"),
+):
+    """Schedule a social media post on X or Facebook."""
+    from urllib.parse import quote_plus
+
+    plat = platform.lower()
+    if plat in {"x", "twitter"}:
+        url = f"https://twitter.com/intent/tweet?text={quote_plus(text)}"
+    elif plat in {"facebook", "fb"}:
+        url = f"https://www.facebook.com/sharer/sharer.php?quote={quote_plus(text)}"
+    else:
+        print("[red]Unsupported platform")
+        raise typer.Exit(1)
+    tasks = _read_tasks()
+    tasks.append({"time": at, "url": url, "done": False})
+    _save_tasks(tasks)
+    print("[green]✓ post scheduled")
+
+
+@app.command()
+def worker(once: bool = False, interval: int = 60):
+    """Execute due browser tasks. Use --once for cron."""
+
+    def process_once():
+        tasks = _read_tasks()
+        now = datetime.datetime.now()
+        changed = False
+        for t in tasks:
+            if not t.get("done") and datetime.datetime.fromisoformat(t["time"]) <= now:
+                webbrowser.open(t["url"])
+                t["done"] = True
+                changed = True
+        if changed:
+            _save_tasks(tasks)
+
+    if once:
+        process_once()
+    else:
+        while True:
+            process_once()
+            time.sleep(interval)
+
+
+@app.command("tasks")
+def tasks_cmd(clear: int = typer.Option(None, "--clear", help="index to remove")):
+    """List scheduled tasks or remove one by index."""
+    tasks = _read_tasks()
+    if clear is not None:
+        if 0 <= clear < len(tasks):
+            del tasks[clear]
+            _save_tasks(tasks)
+            print("[green]✓ removed")
+        return
+    for i, t in enumerate(tasks):
+        status = "done" if t.get("done") else "pending"
+        print(f"{i}: {t['time']} {status} {t['url']}")
+
+
+@app.command()
+def graphs(name: str):
+    """Show monthly interaction counts using a Textual sparkline."""
+    try:
+        from textual.app import App as TApp
+        from textual.widgets import Sparkline
+    except Exception:
+        print("[red]Install textual to use graphs")
+        raise typer.Exit(1)
+    rec = _load(name)
+    counts = defaultdict(int)
+    for i in rec.get("interactions", []):
+        dt = datetime.date.fromisoformat(i["date"])
+        key = dt.strftime("%Y-%m")
+        counts[key] += 1
+    months = sorted(counts)
+    values = [counts[m] for m in months]
+
+    class Graph(TApp):
+        BINDINGS = [("q", "quit", "Quit")]
+
+        def compose(self):
+            yield Sparkline(values=values, width=len(values) * 4, title="Interactions")
+
+    Graph().run()
+
+
+@app.command()
+def undo():
+    """Revert the last commit in the data directory."""
+    if not (data_dir() / ".git").exists():
+        print("[red]No git repository in data dir")
+        raise typer.Exit(1)
+    subprocess.run(
+        ["git", "-C", str(data_dir()), "revert", "--no-edit", "HEAD"], check=False
+    )
+
+
+@app.command()
+def stats():
+    """Print total contacts, interactions and due reminders."""
+    contacts = list(data_dir().glob("*.yaml"))
+    num_contacts = len(contacts)
+    interactions = sum(
+        len(yaml.safe_load(f.read_text()).get("interactions", [])) for f in contacts
+    )
+    due = 0
+    rf = reminders_file()
+    if rf.exists():
+        today = datetime.date.today().isoformat()
+        due = sum(
+            1 for line in rf.read_text().splitlines() if line.split(" ", 1)[0] <= today
+        )
+    print(
+        json.dumps(
+            {
+                "contacts": num_contacts,
+                "interactions": interactions,
+                "due_reminders": due,
+            },
+            indent=2,
+        )
+    )
+
+
+@app.command("tag-all")
+def tag_all(tag: str, names: List[str]):
+    """Add TAG to multiple contacts."""
+    for name in names:
+        rec = _load(name)
+        if tag not in rec.get("tags", []):
+            rec.setdefault("tags", []).append(tag)
+            _save(rec)
+    print("[green]✓ tags updated")
+
+
+@app.command()
+def summary(name: str):
+    """Summarize a contact with AI."""
+    rec = _load(name)
+    resp = _ai(
+        'Summarize this CRM record in <=100 words. Return JSON {"summary":"text"}',
+        json.dumps(rec),
+    )
+    print(resp.get("summary", ""))
+
+
+@app.command("import-csv")
+def import_csv(path: str):
+    """Import contacts from a CSV with columns name,email,tags."""
+    import csv
+
+    with open(path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            name = row.get("name")
+            email = row.get("email", "")
+            tags = row.get("tags", "")
+            if name:
+                if not _path(name).exists():
+                    rec = {
+                        "name": name,
+                        "email": email,
+                        "tags": [t.strip() for t in tags.split(",") if t.strip()],
+                        "created": datetime.date.today().isoformat(),
+                        "interactions": [],
+                        "notes": [],
+                    }
+                    _save(rec)
+
+
+@app.command("notify-due")
+def notify_due():
+    """Send desktop notifications for due reminders."""
+    rf = reminders_file()
+    if not rf.exists():
+        return
+    today = datetime.date.today().isoformat()
+    for line in rf.read_text().splitlines():
+        date, rest = line.split(" ", 1)
+        if date <= today:
+            subprocess.run(["notify-send", "CRMD", rest], check=False)
+
+
+@app.command()
+def encrypt():
+    """Archive and encrypt the data directory with gpg."""
+    tar = data_dir().with_suffix(".tar.gz")
+    subprocess.run(["tar", "czf", str(tar), "-C", str(data_dir()), "."], check=True)
+    subprocess.run(["gpg", "-c", str(tar)], check=False)
+
+
+@app.command("export-json")
+def export_json(name: str, path: str):
+    """Export a contact to PATH as JSON."""
+    rec = _load(name)
+    with open(path, "w") as fh:
+        json.dump(rec, fh, indent=2)
+    print("[green]✓ exported")
+
+
+@app.command("import-json")
+def import_json(path: str):
+    """Import a contact from a JSON file."""
+    with open(path) as fh:
+        rec = json.load(fh)
+    name = rec.get("name")
+    if not name:
+        print("[red]Missing name field")
+        raise typer.Exit(1)
+    if _path(name).exists():
+        print("[red]Contact exists")
+        raise typer.Exit(1)
+    _save(rec)
+    print("[green]✓ imported")
+
+
+@app.command()
+def delete(name: str):
+    """Delete a contact."""
+    p = _path(name)
+    if p.exists():
+        p.unlink()
+        print("[green]✓ deleted")
+    else:
+        print("[red]Contact not found")
+
+
+@app.command()
+def backup(dest: str = typer.Argument("crmd_backup.tar.gz")):
+    """Create a gzipped backup of the data directory."""
+    subprocess.run(["tar", "czf", dest, "-C", str(data_dir()), "."], check=True)
+    print(f"[green]✓ backup written to {dest}")
+
+
+@app.command()
+def merge(source: str, target: str):
+    """Merge SOURCE contact into TARGET and delete SOURCE."""
+    src = _load(source)
+    tgt = _load(target)
+    tgt.setdefault("interactions", []).extend(src.get("interactions", []))
+    tgt.setdefault("notes", []).extend(src.get("notes", []))
+    tags = set(tgt.get("tags", [])) | set(src.get("tags", []))
+    tgt["tags"] = sorted(tags)
+    _save(tgt)
+    _path(source).unlink(missing_ok=True)
+    print("[green]✓ merged")
+
+
+@app.command("export-csv")
+def export_csv(path: str):
+    """Export all contacts to a CSV file."""
+    import csv
+
+    contacts = []
+    for f in sorted(data_dir().glob("*.yaml")):
+        c = yaml.safe_load(f.read_text())
+        contacts.append(
+            {
+                "name": c.get("name"),
+                "email": c.get("email", ""),
+                "tags": ",".join(c.get("tags", [])),
+            }
+        )
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["name", "email", "tags"])
+        w.writeheader()
+        w.writerows(contacts)
+    print("[green]✓ exported")
+
+
+@app.command()
+def edit(name: str):
+    """Open a contact in $EDITOR."""
+    editor = os.environ.get("EDITOR", "nano")
+    subprocess.run([editor, str(_path(name))])
+
+
+@app.command("send-email")
+def send_email(
+    name: str,
+    subject: str = typer.Option(..., "--subject"),
+    body: str = typer.Option(..., "--body"),
+):
+    """Send an email to NAME using environment SMTP settings."""
+    rec = _load(name)
+    to_addr = rec.get("email")
+    if not to_addr:
+        print("[red]No email for contact")
+        raise typer.Exit(1)
+    smtp_server = os.environ.get("SMTP_SERVER")
+    smtp_user = os.environ.get("SMTP_USER")
+    smtp_pass = os.environ.get("SMTP_PASS")
+    smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+    if not smtp_server:
+        print("[red]Set SMTP_SERVER")
+        raise typer.Exit(1)
+    from email.message import EmailMessage
+    import smtplib
+
+    msg = EmailMessage()
+    msg["From"] = smtp_user or to_addr
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    with smtplib.SMTP(smtp_server, smtp_port) as s:
+        if smtp_user:
+            s.starttls()
+            s.login(smtp_user, smtp_pass or "")
+        s.send_message(msg)
+    print("[green]✓ email sent")
+
+
+@app.command("create-event")
+def create_event(
+    name: str,
+    summary: str = typer.Option(..., "--summary"),
+    when: str = typer.Option(..., "--when", help="YYYY-MM-DD HH:MM"),
+):
+    """Write an ICS calendar event for NAME."""
+    rec = _load(name)
+    dt = datetime.datetime.fromisoformat(when)
+    path = data_dir() / f"{dt.date()}_{rec['name'].replace(' ', '_')}.ics"
+    ics = (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "BEGIN:VEVENT\n"
+        f"DTSTAMP:{datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}\n"
+        f"DTSTART:{dt.strftime('%Y%m%dT%H%M%S')}\n"
+        f"SUMMARY:{summary}\n"
+        f"ATTENDEE:{rec.get('email','')}\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+    path.write_text(ics)
+    print(f"[green]✓ event saved to {path}")
+
+
+@app.command()
+def fullscreen():
+    """Full-screen Textual UI."""
+    try:
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable, Header, Footer
+    except Exception:
+        print("[red]Install textual first: pip install textual")
+        raise typer.Exit(1)
+
+    class Full(App):
+        BINDINGS = [("q", "quit", "Quit")]
+
+        def compose(self) -> ComposeResult:
+            yield Header()
+            tbl = DataTable(zebra_stripes=True)
+            tbl.add_columns("Name", "Email", "Tags")
+            for f in sorted(data_dir().glob("*.yaml")):
+                c = yaml.safe_load(f.read_text())
+                tbl.add_row(c["name"], c.get("email", ""), ",".join(c.get("tags", [])))
+            yield tbl
+            yield Footer()
+
+    Full().run()
+
+
+@app.command("sync-cloud")
+def sync_cloud(remote: str = typer.Option("origin", "--remote")):
+    """Push the data directory to a git remote."""
+    if not (data_dir() / ".git").exists():
+        print("[red]No git repository in data dir")
+        raise typer.Exit(1)
+    subprocess.run(["git", "-C", str(data_dir()), "add", "."], check=False)
+    subprocess.run(["git", "-C", str(data_dir()), "commit", "-m", "sync"], check=False)
+    subprocess.run(["git", "-C", str(data_dir()), "push", remote], check=False)
+    print("[green]✓ pushed")
+
+
+@app.command("list-tags")
+def list_tags():
+    """List all unique tags."""
+    tags = set()
+    for f in data_dir().glob("*.yaml"):
+        c = yaml.safe_load(f.read_text())
+        tags.update(c.get("tags", []))
+    for t in sorted(tags):
+        print(t)
+
+
+def worker_cmd():
+    """Entry point for systemd timers."""
+    worker()
+
+
+if __name__ == "__main__":
+    app()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>crmd – Terminal CRM</title>
+<style>
+body { background: #2d2d2d; color: #ddd; font-family: monospace; padding: 2rem; }
+h1 { color: #87d787; }
+a { color: #5fd7ff; }
+.box { border: 1px solid #555; padding: 1rem; margin-bottom: 1rem; background: #1e1e1e; }
+</style>
+</head>
+<body>
+<h1>crmd</h1>
+<p>A small, terminal-first CRM that stores YAML files locally and uses OpenAI to help plan your next move.</p>
+<div class="box">
+<h2>Features</h2>
+<ul>
+<li>Quick CLI for adding contacts and logging interactions</li>
+<li>AI-assisted planning and summaries</li>
+<li>Reminders, git sync, and browser task scheduling</li>
+<li>Textual dashboard and charts</li>
+</ul>
+</div>
+<p>Install with:</p>
+<pre>pip install crmd</pre>
+<p>Then run <code>crmd --help</code> to explore.</p>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "crmd"
+version = "0.2.1"
+description = "Terminal CRM with OpenAI integration"
+authors = [{name="Your Name"}]
+requires-python = ">=3.8"
+dependencies = [
+    "typer[all]",
+    "pyyaml",
+    "rich",
+    "textual",
+    "openai"
+]
+
+[project.scripts]
+crmd = "crmd:app"
+crmd-worker = "crmd:worker_cmd"

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,5 @@
+typer[all]
+pyyaml
+rich
+textual
+openai

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+VERSION=${1:-0.1.0}
+PKGDIR=$(mktemp -d)
+install -Dm755 crmd.py "$PKGDIR/usr/bin/crmd"
+cat > "$PKGDIR/DEBIAN/control" <<CTL
+Package: crmd
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: all
+Maintainer: Your Name
+Description: Terminal CRM with OpenAI integration
+CTL
+dpkg-deb --build "$PKGDIR" "crmd_${VERSION}_all.deb"
+rm -rf "$PKGDIR"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from setuptools import setup
+
+
+def _read_requirements():
+    req_path = Path(__file__).with_name("requirements.in")
+    return [line.strip() for line in req_path.read_text().splitlines() if line.strip()]
+
+
+setup(
+    name="crmd",
+    version="0.2.0",
+    py_modules=["crmd"],
+    install_requires=_read_requirements(),
+    entry_points={"console_scripts": ["crmd=crmd:app", "crmd-worker=crmd:worker_cmd"]},
+)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,308 @@
+import os
+import yaml
+from typer.testing import CliRunner
+from crmd import app, data_dir, _path
+
+runner = CliRunner()
+
+
+def test_add_and_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    result = runner.invoke(app, ["add", "Test User", "--email", "test@example.com"])
+    assert result.exit_code == 0
+    assert _path("Test User").exists()
+
+    result = runner.invoke(app, ["list"])
+    assert "Test User" in result.stdout
+
+
+def test_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "U", "--email", "u@e.com"])
+    result = runner.invoke(app, ["log", "U", "--summary", "hi"])
+    assert result.exit_code == 0
+    data = yaml.safe_load(_path("U").read_text())
+    assert len(data["interactions"]) == 1
+
+
+def test_search(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "Alice", "--email", "a@b.com"])
+    res = runner.invoke(app, ["search", "Alice"])
+    assert "Alice" in res.stdout
+
+
+def test_remind_due(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["remind", "Alice", "hi", "--in", "0"])
+    res = runner.invoke(app, ["due"])
+    assert "Alice" in res.stdout
+
+
+def test_schedule_and_worker(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "crmd._ai",
+        lambda s, u: {
+            "run_at": "2020-01-01 00:00",
+            "to": "U",
+            "subject": "hi",
+            "body": "body",
+        },
+    )
+    runner.invoke(app, ["add", "U", "--email", "u@e.com"])
+    called = {}
+
+    def fake_open(url):
+        called["url"] = url
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+    runner.invoke(app, ["schedule", "email U"])
+    runner.invoke(app, ["worker", "--once"])
+    assert "mail.google.com" in called["url"]
+
+
+def test_schedule_post(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    called = {}
+
+    def fake_open(url):
+        called["url"] = url
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+    runner.invoke(
+        app,
+        ["schedule-post", "hello world", "--platform", "x", "--at", "2020-01-01 00:00"],
+    )
+    runner.invoke(app, ["worker", "--once"])
+    assert "twitter.com" in called["url"]
+
+
+def test_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "Bob", "--email", "b@b.com"])
+    monkeypatch.setattr("crmd._ai", lambda s, u: {"summary": "hi"})
+    res = runner.invoke(app, ["summary", "Bob"])
+    assert "hi" in res.stdout
+
+
+def test_import_csv(tmp_path, monkeypatch):
+    import csv, tempfile
+
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    csv_path = tmp_path / "c.csv"
+    with csv_path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["name", "email", "tags"])
+        w.writeheader()
+        w.writerow({"name": "Carla", "email": "c@c.com", "tags": "vip"})
+    runner.invoke(app, ["import-csv", str(csv_path)])
+    assert _path("Carla").exists()
+
+
+def test_notify_due(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["remind", "Alice", "hi", "--in", "0"])
+    called = {}
+
+    def fake_run(cmd, check=False):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    runner.invoke(app, ["notify-due"])
+    assert called["cmd"][0] == "notify-send"
+
+
+def test_graphs(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "Alice", "--email", "a@b.com"])
+    runner.invoke(app, ["log", "Alice", "--summary", "a"])
+    monkeypatch.setattr("textual.app.App.run", lambda self: None)
+    res = runner.invoke(app, ["graphs", "Alice"])
+    assert res.exit_code == 0
+
+
+def test_undo_and_stats(tmp_path, monkeypatch):
+    import subprocess
+
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "U", "--email", "u@e.com"])
+    subprocess.run(["git", "-C", str(tmp_path), "init"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "init"], check=True)
+    runner.invoke(app, ["log", "U", "--summary", "hello"])
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "log"], check=True)
+    runner.invoke(app, ["undo"])
+    data = yaml.safe_load(_path("U").read_text())
+    assert len(data["interactions"]) == 0
+    res = runner.invoke(app, ["stats"])
+    assert "contacts" in res.stdout
+
+
+def test_tag_all(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+    runner.invoke(app, ["add", "B", "--email", "b@b.com"])
+    runner.invoke(app, ["tag-all", "vip", "A", "B"])
+    a = yaml.safe_load(_path("A").read_text())
+    b = yaml.safe_load(_path("B").read_text())
+    assert "vip" in a["tags"] and "vip" in b["tags"]
+
+
+def test_export_import_delete_backup(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "X", "--email", "x@e.com"])
+    export_path = tmp_path / "x.json"
+    runner.invoke(app, ["export-json", "X", str(export_path)])
+    assert export_path.exists()
+
+    runner.invoke(app, ["delete", "X"])
+    assert not _path("X").exists()
+
+    runner.invoke(app, ["import-json", str(export_path)])
+    assert _path("X").exists()
+
+    backup_path = tmp_path / "b.tar.gz"
+    runner.invoke(app, ["backup", str(backup_path)])
+    assert backup_path.exists()
+
+
+def test_merge_export_csv_edit_list_tags(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com", "--tags", "vip"])
+    runner.invoke(app, ["add", "B", "--email", "b@b.com", "--tags", "new"])
+    runner.invoke(app, ["merge", "A", "B"])
+    assert not _path("A").exists()
+    data = yaml.safe_load(_path("B").read_text())
+    assert "vip" in data["tags"]
+    csv_path = tmp_path / "all.csv"
+    runner.invoke(app, ["export-csv", str(csv_path)])
+    assert csv_path.exists()
+    called = {}
+    monkeypatch.setenv("EDITOR", "vim")
+    monkeypatch.setattr("subprocess.run", lambda cmd: called.setdefault("cmd", cmd))
+    runner.invoke(app, ["edit", "B"])
+    assert called["cmd"][0] == "vim"
+    res = runner.invoke(app, ["list-tags"])
+    assert "vip" in res.stdout and "new" in res.stdout
+
+
+def test_config_and_ai(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    calls = {}
+
+    class FakeOpenAI:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**_):
+                    calls["used"] = True
+
+                    class C:
+                        pass
+
+                    c = C()
+                    c.message = C()
+                    c.message.content = "{}"
+                    result = C()
+                    result.choices = [c]
+                    return result
+
+    monkeypatch.setattr("crmd.openai", FakeOpenAI)
+    runner.invoke(app, ["add", "B", "--email", "b@b.com"])
+    runner.invoke(app, ["config", "set-api-key", "k"])
+    res = runner.invoke(
+        app, ["plan", "B"], env={"OPENAI_API_KEY": "", "CRMD_HOME": str(tmp_path)}
+    )
+    assert res.exit_code != 1
+
+
+def test_list_filter(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com", "--tags", "x"])
+    runner.invoke(app, ["add", "B", "--email", "b@b.com", "--tags", "y"])
+    res = runner.invoke(app, ["list", "--tag", "x"])
+    assert "A" in res.stdout and "B" not in res.stdout
+
+
+def test_reminders_and_tasks(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["remind", "A", "hi", "--in", "0"])
+    res = runner.invoke(app, ["reminders"])
+    assert "A" in res.stdout
+    runner.invoke(app, ["reminders", "--clear", "0"])
+    res = runner.invoke(app, ["reminders"])
+    assert "A" not in res.stdout
+
+    runner.invoke(app, ["schedule-browser", "http://e.com", "--at", "2020-01-01 00:00"])
+    res = runner.invoke(app, ["tasks"])
+    assert "http://e.com" in res.stdout
+    runner.invoke(app, ["tasks", "--clear", "0"])
+    res = runner.invoke(app, ["tasks"])
+    assert "http://e.com" not in res.stdout
+
+
+def test_send_email(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+
+    sent = {}
+
+    class FakeSMTP:
+        def __init__(self, host, port):
+            sent["server"] = (host, port)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def starttls(self):
+            sent["tls"] = True
+
+        def login(self, user, pw):
+            sent["login"] = (user, pw)
+
+        def send_message(self, msg):
+            sent["to"] = msg["To"]
+
+    monkeypatch.setattr("smtplib.SMTP", FakeSMTP)
+    monkeypatch.setenv("SMTP_SERVER", "host")
+    monkeypatch.setenv("SMTP_USER", "u")
+    monkeypatch.setenv("SMTP_PASS", "p")
+    res = runner.invoke(app, ["send-email", "A", "--subject", "s", "--body", "b"])
+    assert res.exit_code == 0
+    assert sent["to"] == "a@b.com"
+
+
+def test_create_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+    res = runner.invoke(
+        app,
+        ["create-event", "A", "--summary", "Meet", "--when", "2020-01-01 00:00"],
+    )
+    assert res.exit_code == 0
+    assert list(tmp_path.glob("*.ics"))
+
+
+def test_fullscreen(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+    monkeypatch.setattr("textual.app.App.run", lambda self: None)
+    res = runner.invoke(app, ["fullscreen"])
+    assert res.exit_code == 0
+
+
+def test_sync_cloud(tmp_path, monkeypatch):
+    import subprocess
+
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+    subprocess.run(["git", "-C", str(tmp_path), "init"], check=True)
+    called = []
+    monkeypatch.setattr("subprocess.run", lambda cmd, check=False: called.append(cmd))
+    runner.invoke(app, ["sync-cloud"])
+    assert any("push" in c for c in called[2])


### PR DESCRIPTION
## Summary
- implement an AI-assisted CRM CLI (`crmd.py`)
- provide installation and usage docs with systemd example
- add search, reminder, git sync and email drafting commands
- include tests for basic commands
- add packaging, CI workflow, Debian package script, and browser task scheduler
- implement AI summary, CSV import, notifications, and encryption support
- add graph, undo, stats, and bulk tagging commands
- update README examples and document future ideas
- add scheduler for social media posts and document in README
- improve installation docs using `uv` and adjust CI for Python 3.12
- add export/import JSON, delete and backup commands with tests
- provide a small demo `index.html` site
- add natural language `schedule` and background `worker` commands
- implement merge, CSV export, editor launch and tag listing
- add config command and task/reminder management
- add email sending, calendar event export, full-screen UI, and cloud sync commands

## Testing
- `python -m venv .venv`
- `source .venv/bin/activate`
- `pip install uv`
- `uv pip install -r requirements.in`
- `uv pip install -e .`
- `pip install pytest`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e1bca8cd88333b5a57a4dfdf3c10a