### PR TITLE
Add usability commands and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,16 @@ set.
 
 For a quick visual overview, open `index.html` in your browser to see a minimal demo site styled like a terminal.
 
+## Implemented nice-to-haves
+
+- Mobile-friendly shell wrapper (`crmd mobile-shell`)
+- Voice note recording (`crmd record-voice NAME`)
+- Local search index (`crmd build-index` and `crmd fast-search`)
+- Contact deduplication suggestions (`crmd dedupe`)
+
 ## Next nice-to-haves
 
-- Mobile-friendly shell wrapper
-- Voice note recording
-- Local search index for speed
-- Contact deduplication suggestions
+- Basic web helper command
+- Improved mobile UI theme
+- Automated voice transcription
+- Cloud indexing for multi-device search

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,54 @@
+import os
+import json
+from typer.testing import CliRunner
+from crmd import app, _index_file, _path
+
+runner = CliRunner()
+
+
+def test_web(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    called = {}
+    monkeypatch.setattr("webbrowser.open", lambda url: called.setdefault("url", url))
+    res = runner.invoke(app, ["web"])
+    assert res.exit_code == 0
+    assert "index.html" in called["url"]
+
+
+def test_mobile_shell(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    seq = iter(["exit"])
+    monkeypatch.setattr("crmd.Prompt.ask", lambda *_: next(seq))
+    res = runner.invoke(app, ["mobile-shell"])
+    assert res.exit_code == 0
+
+
+def test_record_voice(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "A", "--email", "a@b.com"])
+    called = {}
+    def fake_run(cmd, check=False):
+        called['cmd'] = cmd
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = runner.invoke(app, ["record-voice", "A", "--seconds", "1"])
+    assert res.exit_code == 0
+    assert "sox" in called['cmd'][0]
+
+
+def test_build_index_and_fast_search(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "Alice", "--email", "a@b.com"])
+    runner.invoke(app, ["add", "Bob", "--email", "b@b.com"])
+    runner.invoke(app, ["log", "Bob", "--summary", "hi"])
+    runner.invoke(app, ["build-index"])
+    assert _index_file().exists()
+    res = runner.invoke(app, ["fast-search", "bob"])
+    assert "Bob" in res.stdout
+
+
+def test_dedupe(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRMD_HOME", str(tmp_path))
+    runner.invoke(app, ["add", "Ann", "--email", "x@y.com"])
+    runner.invoke(app, ["add", "Anne", "--email", "x@y.com"])
+    res = runner.invoke(app, ["dedupe"])
+    assert "same email" in res.stdout


### PR DESCRIPTION
## Summary
- add `web` command to open `index.html`
- implement `mobile-shell`, `record-voice`, `build-index`, `fast-search`, and `dedupe`
- document implemented features and next ideas in README
- add tests for new commands

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea5daaa408333b29744afbe5789be